### PR TITLE
kernel: add missing in6_dev_put_clear call to an ipv6 network patch

### DIFF
--- a/target/linux/generic/patches-4.4/670-ipv6-allow-rejecting-with-source-address-failed-policy.patch
+++ b/target/linux/generic/patches-4.4/670-ipv6-allow-rejecting-with-source-address-failed-policy.patch
@@ -202,7 +202,15 @@ Signed-off-by: Jonas Gorski <jogo@openwrt.org>
  		net->ipv6.ip6_blk_hole_entry->dst.dev = dev;
  		net->ipv6.ip6_blk_hole_entry->rt6i_idev = in6_dev_get(dev);
  #endif
-@@ -3605,6 +3644,17 @@ static int __net_init ip6_route_net_init
+@@ -3390,6 +3429,7 @@ static int ip6_route_dev_notify(struct n
+ 		in6_dev_put(net->ipv6.ip6_null_entry->rt6i_idev);
+ #ifdef CONFIG_IPV6_MULTIPLE_TABLES
+ 		in6_dev_put(net->ipv6.ip6_prohibit_entry->rt6i_idev);
++		in6_dev_put(net->ipv6.ip6_policy_failed_entry->rt6i_idev);
+ 		in6_dev_put(net->ipv6.ip6_blk_hole_entry->rt6i_idev);
+ #endif
+ 	}
+@@ -3605,6 +3645,17 @@ static int __net_init ip6_route_net_init
  	net->ipv6.ip6_blk_hole_entry->dst.ops = &net->ipv6.ip6_dst_ops;
  	dst_init_metrics(&net->ipv6.ip6_blk_hole_entry->dst,
  			 ip6_template_metrics, true);
@@ -220,7 +228,7 @@ Signed-off-by: Jonas Gorski <jogo@openwrt.org>
  #endif
  
  	net->ipv6.sysctl.flush_delay = 0;
-@@ -3623,6 +3673,8 @@ out:
+@@ -3623,6 +3674,8 @@ out:
  	return ret;
  
  #ifdef CONFIG_IPV6_MULTIPLE_TABLES
@@ -229,7 +237,7 @@ Signed-off-by: Jonas Gorski <jogo@openwrt.org>
  out_ip6_prohibit_entry:
  	kfree(net->ipv6.ip6_prohibit_entry);
  out_ip6_null_entry:
-@@ -3640,6 +3692,7 @@ static void __net_exit ip6_route_net_exi
+@@ -3640,6 +3693,7 @@ static void __net_exit ip6_route_net_exi
  #ifdef CONFIG_IPV6_MULTIPLE_TABLES
  	kfree(net->ipv6.ip6_prohibit_entry);
  	kfree(net->ipv6.ip6_blk_hole_entry);
@@ -237,7 +245,7 @@ Signed-off-by: Jonas Gorski <jogo@openwrt.org>
  #endif
  	dst_entries_destroy(&net->ipv6.ip6_dst_ops);
  }
-@@ -3713,6 +3766,9 @@ void __init ip6_route_init_special_entri
+@@ -3713,6 +3767,9 @@ void __init ip6_route_init_special_entri
  	init_net.ipv6.ip6_prohibit_entry->rt6i_idev = in6_dev_get(init_net.loopback_dev);
  	init_net.ipv6.ip6_blk_hole_entry->dst.dev = init_net.loopback_dev;
  	init_net.ipv6.ip6_blk_hole_entry->rt6i_idev = in6_dev_get(init_net.loopback_dev);


### PR DESCRIPTION
Fixes "unregister_netdevice: waiting for lo to become free. Usage count = 1"
messages which started appearing since the update to 4.4.103. That
problem was exposed by upstream commit 76da0704507bb ("ipv6: only call
ip6_route_dev_notify() once for NETDEV_UNREGISTER") backported to 4.4.x
branch in 2417da3f4d6bc.

Fixes: 2b664499cd622 ("kernel: bump 4.4 to 4.4.103 for 17.01")
Signed-off-by: Felix Fietkau <nbd@nbd.name>
Signed-off-by: Rafał Miłecki <rafal@milecki.pl>

(cherry picked from commit 58f7b5b96c301176d639540df4723c798af2a999)